### PR TITLE
Add possibility to copyfiles

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -6,6 +6,7 @@ module.exports = {
     stats: false,
     caching: true,
     linting: true,
-    sourcemaps: true
+    sourcemaps: true,
+    copyFiles: []
   }
 };

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -2,6 +2,7 @@ const path = require("path");
 const webpack = require("webpack");
 const slsw = require("serverless-webpack");
 const HardSourceWebpackPlugin = require("hard-source-webpack-plugin");
+const CopyWebpackPlugin = require("copy-webpack-plugin");
 
 const config = require("./config");
 const eslintConfig = require("./eslintrc.json");
@@ -92,6 +93,18 @@ function plugins() {
           level: ENABLE_STATS ? "debug" : "error"
         }
       })
+    );
+  }
+
+  if (config.options.copyFiles) {
+    plugins.push(
+      new CopyWebpackPlugin(
+        config.options.copyFiles.map(data => ({
+          from: path.join(config.servicePath, data.from),
+          to: data.to,
+          context: config.servicePath
+        }))
+      )
     );
   }
 


### PR DESCRIPTION
I realized that you already had copy-webpack-plugin as dependency so added ability to configure it.

Added a new configuration option copyFiles:

```yaml
    copyFiles:
      - to: './'
        from: 'src/templates/*'
```
Only exposed 'to' and 'from' parameters. Automatically also setting context to servicePath. 

Mainly configured to fit my needs so might be that makes sense to expose other parameters also or remove those and just hardcode some 'public' -directory which gets automatically copied.

Related to #16 

Hope that this could go in in some form.
