### PR TITLE
ignore electron

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -128,7 +128,7 @@ module.exports = ignoreWarmupPlugin({
   stats: ENABLE_STATS ? "normal" : "errors-only",
   devtool: ENABLE_SOURCE_MAPS ? "source-map" : false,
   // Exclude "aws-sdk" since it's a built-in package
-  externals: ["aws-sdk"],
+  externals: ["aws-sdk", "electron"],
   mode: isLocal ? "development" : "production",
   performance: {
     // Turn off size warnings for entry points


### PR DESCRIPTION
I am working with mapbox and I ran into an error that was stopping me from deploying, so I added electron to ignore in the webpack config, mapbox works now