### PR TITLE
Yarn packager support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ custom:
     copyFiles:            # Copy any additional files to the generated package
       - from: 'public/*'    # Where the files are currently
         to: './'            # Where in the package should they go
+    packager: 'yarn'        # Use 'yarn' packager. The default is 'npm'
     packagerOptions:      # Run a custom script in the package process
       scripts:              # https://github.com/serverless-heaven/serverless-webpack#custom-scripts
         - echo hello > test

--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ function applyCustomOptions(custom, config) {
       forceInclude: config.options.forceInclude
     }
   };
+
+  if (custom.bundle && custom.bundle.packager) {
+    custom.webpack.packager = custom.bundle.packager;
+  }
 }
 
 function applyConfigOptions(config, options, servicePath, runtime) {


### PR DESCRIPTION
Thanks for this plugin. 

This PR  adds Yarn packager support. Here is the related issue: https://github.com/AnomalyInnovations/serverless-bundle/issues/20.

How it works:
1. since customizing of `serverless-webpack` in `serverless.yml` is not allowed, the `packager` option can be defined in the current plugin
2. if `packager` option is defined, then it is just passed to `serverless-webpack` plugin.

I have made this PR to `beta` branch because I noticed recent development there.

Let me know what you think about it. If tests are needed, please let me know. 