### PR TITLE
fix: __dirname for nodejs

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -161,5 +161,8 @@ module.exports = ignoreWarmupPlugin({
     : // Don't minimize in production
       // Large builds can run out of memory
       { minimize: false },
-  plugins: plugins()
+  plugins: plugins(),
+  node: {
+    __dirname: false
+  }
 });


### PR DESCRIPTION
👋👋👋

Thanks for your plugin! It's awesome. I have started using it and noticed that my Lambda which uses `__dirname` to compose the path to a static file, is no longer working.

By default, in Webpack, `__dirname` is set to `/`. That's a typical Front-End behaviour which in Node.js breaks things. I read a few blog posts about this and I'll leave one which is very clear about this setting, so you can use it to review this PR if you want.

https://codeburst.io/use-webpack-with-dirname-correctly-4cad3b265a92

I hope to see this merged soon, so I can keep using your version in my project.