### PR TITLE
Added support for concatenating files

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ custom:
     copyFiles:                # Copy any additional files to the generated package
       - from: 'public/*'        # Where the files are currently
         to: './'                # Where in the package should they go
+    concatText:               # Concatenate text files into one file on the generated package
+      - files: 'schema/*.txt'   # Where the files that need to be concatenated are currently located
+        outputPath: './'        # Where the concatenated file should go in the package
+        name: 'schema.txt'      # The name the the concatenated file should have
     packager: npm             # Specify a packager, 'npm' or 'yarn'. Defaults to 'npm'.
     packagerOptions:          # Run a custom script in the package process
       scripts:                  # https://github.com/serverless-heaven/serverless-webpack#custom-scripts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-bundle",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4548,6 +4548,14 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "concat": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/concat/-/concat-1.0.3.tgz",
+      "integrity": "sha1-QPM1MInWVGdpXLGIa0Xt1jfYzKg=",
+      "requires": {
+        "commander": "^2.9.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4562,6 +4570,45 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "concat-text-webpack-plugin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/concat-text-webpack-plugin/-/concat-text-webpack-plugin-0.1.4.tgz",
+      "integrity": "sha512-dZoPYASD/OQNKEhAxpn7MkczBMISPxAZCJ5Szj/1O1Ka5FpmjofDyQW0iaORx9uHL++hwTP8uQaaeIrle2ukug==",
+      "requires": {
+        "concat": "1.0.3",
+        "glob": "7.1.6",
+        "webpack-sources": "1.4.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "webpack-sources": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+          "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+          "requires": {
+            "source-list-map": "^2.0.0",
+            "source-map": "~0.6.1"
+          }
+        }
       }
     },
     "console-browserify": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-loader": "^8.0.6",
     "babel-plugin-source-map-support": "^2.1.1",
     "chalk": "^2.4.2",
+    "concat-text-webpack-plugin": "^0.1.4",
     "copy-webpack-plugin": "^5.0.3",
     "core-js": "^3.1.4",
     "cross-spawn": "^6.0.5",

--- a/src/config.js
+++ b/src/config.js
@@ -9,6 +9,7 @@ module.exports = {
     linting: true,
     packager: "npm",
     copyFiles: null,
+    concatText: null,
     sourcemaps: true,
     forceInclude: null,
     ignorePackages: [],

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -3,6 +3,7 @@ const webpack = require("webpack");
 const slsw = require("serverless-webpack");
 const HardSourceWebpackPlugin = require("hard-source-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
+const ConcatTextPlugin = require("concat-text-webpack-plugin");
 const fs = require("fs");
 
 const config = require("./config");
@@ -15,6 +16,7 @@ const isLocal = slsw.lib.webpack.isLocal;
 const servicePath = config.servicePath;
 const nodeVersion = config.nodeVersion;
 const copyFiles = config.options.copyFiles;
+const concatText = config.options.concatText;
 const ignorePackages = config.options.ignorePackages;
 const tsConfigPath = path.resolve(servicePath, "./tsconfig.json");
 
@@ -91,10 +93,10 @@ function loaders() {
         exclude: /node_modules/,
         use: [babelLoader()]
       },
-      { 
+      {
         test: /\.(graphql|gql)$/,
         exclude: /node_modules/,
-        loader: 'graphql-tag/loader'
+        loader: "graphql-tag/loader"
       }
     ]
   };
@@ -158,6 +160,18 @@ function plugins() {
         })
       )
     );
+  }
+
+  if (concatText) {
+    const concatTextConfig = {};
+
+    concatText.map(function(data) {
+      concatTextConfig.files = data.files || null;
+      concatTextConfig.name = data.name || null;
+      concatTextConfig.outputPath = data.outputPath || null;
+    });
+
+    plugins.push(new ConcatTextPlugin(concatTextConfig));
   }
 
   // Ignore all locale files of moment.js

--- a/tests/concat-text/.gitignore
+++ b/tests/concat-text/.gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/tests/concat-text/handler.js
+++ b/tests/concat-text/handler.js
@@ -1,0 +1,9 @@
+export const hello = async (event, context) => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: "Go Serverless v1.0! Your function executed successfully!",
+      input: event
+    })
+  };
+};

--- a/tests/concat-text/package-lock.json
+++ b/tests/concat-text/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "concat-text",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/tests/concat-text/package.json
+++ b/tests/concat-text/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "concat-text",
+  "version": "1.0.0",
+  "description": "",
+  "main": "handler.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/tests/concat-text/public/test-1.txt
+++ b/tests/concat-text/public/test-1.txt
@@ -1,0 +1,1 @@
+This file should be concatenated and this line should appear first in the file.

--- a/tests/concat-text/public/test-2.txt
+++ b/tests/concat-text/public/test-2.txt
@@ -1,0 +1,1 @@
+This file should also be concatenated and this line should appear second in the file.

--- a/tests/concat-text/serverless.yml
+++ b/tests/concat-text/serverless.yml
@@ -1,0 +1,19 @@
+service: my-service
+
+plugins:
+  - '../../index'
+
+custom:
+  bundle:
+    concatText:
+      - files: 'public/*'
+        outputPath: './static'
+        name: 'test-concat.txt'
+
+provider:
+  name: aws
+  runtime: nodejs10.x
+
+functions:
+  hello:
+    handler: handler.hello

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -90,6 +90,14 @@ test("copy files", () => {
   ).toBe(true);
 });
 
+test("concat text", () => {
+  const results = runSlsCommand("concat-text");
+  expect(results).not.toContain(errorString);
+  expect(
+    fs.existsSync("tests/concat-text/.webpack/service/static/test-concat.txt")
+  ).toBe(true);
+});
+
 function clearNodeModules(cwd) {
   const { stdout, error } = spawnSync("rm", ["-rf", "node_modules/"], {
     cwd,


### PR DESCRIPTION
Like a lot of developers, I like to use GraphQL, but my schema definition files get unmanageably large quickly. So, I like to split my schema definition files up into multiple, smaller schema files to modularize them.

Typically, one would simply copy the entire directory of schema definition files over to their production deployment and load it with some sort of loader. I noticed that `serverless-bundle` uses the `copy-webpack-plugin` to allow users to copy files or directories into their final package. This is great for quickly copying over an entire directory of schema definition files:

``` yaml
custom:
  bundle:
    copyFiles:
      - from: 'src/schema/*'
        to: './'
```

BUT sometimes there's a need to not just copy the files over, but also concatenate them into one file during deployment. GraphQL schema definition files are essentially just a bunch of text files anyways, so gluing them back together when you deploy your app _should_ be pretty easy...

Unfortunately, it's not that easy when you're dealing with AWS Lambda.

When I go to package and deploy my service to AWS Lambda, I'm faced with an interesting challenge: I can either copy my entire directory of schema files over to AWS and load them recursively on every single request (slows down execution with file I/O), OR I have to concatenate all of my schema files into one file manually before deployment and then copy that one concatenated file into my package that gets uploaded to Lambda and load it there (time consuming deployment). Both of these options are not ideal for large schemas.

From a performance standpoint, loading 1 schema file is better than loading 100 and concatenating them on the fly, and I could surely write a script to do that, but there's already a [wonderful webpack plugin](https://github.com/namics/webpack-concat-text-plugin) for concatenating plain text files.

I integrated `concat-text-webpack-plugin` with `serverless-bundle` to add plain-text concatenation functionality to `serverless-bundle`'s webpack config and am contributing it back in this pull request because I figure there's a lot of frustrated GraphQL devs out there like me that need this tool!

Now I can take that same `schema` directory and concatenate the whole thing into one `schema.gql` file on deployment like this:
``` yaml
custom:
  bundle:
    concatText:
      - files: 'src/schema/*.gql'
        outputPath: './src'
        name: 'schema.gql'
```

I hope that this feature is helpful to someone else too!!

### Real-life use case with GraphQL
Here's an example of how I use this for GraphQL schema file modularization:

I have the following GraphQL schema, and I want to split it out into 3 separate files to modularize it.

``` graphql
Query {
  users: [User!]
}

type User {
  id: ID
  notes: [Note!]
}

type Note {
  id: ID
  user: User
  content: String
}
```

First, I create a directory `schema` in the `src` directory of my app.

Then, I create 3 files and divide my schema amongst them:

#### **`__base.gql`**
_This file sets up my base schema and will be concatenated first since it's underscored_
``` graphql
# We need to create a new type for the queries so that we can extend them in the modularized files
type QueryType {
  _: Boolean
}

# We need to create a new type for the mutations so that we can extend them in the modularized files
type MutationType {
  _: Boolean
}

# Here we match our new extendable query and mutation types to the schema
schema {
  query: QueryType
  mutation: MutationType
}
```

#### **`User.gql`**
_This file defines my User_
``` graphql
type User {
  id: ID
}

# We extend QueryType to add a new query to the schema defined in __base.gql
extend type QueryType {
  users: [User!]
}
```

#### **`Note.gql`**
_This file defines my Note node, which can be owned by a User_
``` graphql
type Note {
  id: ID
  user: User
  content: String
}

# We extend the User defined in the User.gql file to add notes to their node
extend type User {
  notes: [Note!]
}
```

Finally, in `serverless.yml` I add this:
``` yaml
custom:
  bundle:
    concatText:
      - files: 'src/schema/*.gql'
        outputPath: './src'
        name: 'schema.gql'
```

Now, when `serverless-bundle` runs, it'll load `concat-text-webpack-plugin` and read all of the files that match `src/schema/*.gql`. Next, it'll concatenate them and output them as one file (`schema.gql`) in the same folder as the packaged `handler.js` file (`./src`). The finished file will look like this:

``` graphql
# We need to create a new type for the queries so that we can extend them in the modularized files
type QueryType {
  _: Boolean
}

# We need to create a new type for the mutations so that we can extend them in the modularized files
type MutationType {
  _: Boolean
}

# Here we match our new extendable query and mutation types to the schema
schema {
  query: QueryType
  mutation: MutationType
}

type User {
  id: ID
}

# We extend QueryType to add a new query to the schema defined in __base.gql
extend type QueryType {
  users: [User!]
}

type Note {
  id: ID
  user: User
  content: String
}

# We extend the User defined in the User.gql file to add notes to their node
extend type User {
  notes: [Note!]
}
```

To any standard GraphQL server, this looks like one long schema file. We can load this concatenated schema file in Apollo Server (or your GraphQL resolver of choice) by simply converting the contents of the file to a string. I prefer to use `process.env.LAMBDA_TASK_ROOT` to help me track down my service's absolute directory as Serverless and `__dirname` don't seem to get along. Here's a simplified version of what I use to convert my schema file to a string in production:

``` js
import { readFileSync } from 'fs'
const schema = readFileSync(process.env.LAMBDA_TASK_ROOT + '/src/schema.gql).toString()
```

And that's it! Now you have GraphQL schema file concatenation on deployment with no extra headaches or scripts!