### PR TITLE
Enable setting alternative testresultprocessors or reporters for jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ custom:
 
   Here is some info on how to get this plugin to support running tests in WebStorm — https://github.com/AnomalyInnovations/serverless-bundle/issues/5#issuecomment-582237396
 
+- Jest
+
+  Setup: Install jest-mocha-reporter`
+  
+  To test the testResultsProcessor option, add `"testResultsProcessor": "jest-mocha-reporter" to the jest-section in package.json. You should see the default command line output when running npm run test-scripts, but you should also get a test-report.json.
+  
+  To test the reporters option, add `"reporters": ["jest-mocha-reporter"]` instead. This should result in the same file as above but without the command line output.
+
 ### Package Specific Config
 
 The packages below need some additional config to make them work.

--- a/scripts/config/createJestConfig.js
+++ b/scripts/config/createJestConfig.js
@@ -39,10 +39,12 @@ module.exports = (resolve, rootDir, isTestMode) => {
     "extraGlobals",
     "globalSetup",
     "globalTeardown",
+    "reporter",
     "resetMocks",
     "resetModules",
     "setupFilesAfterEnv",
     "snapshotSerializers",
+    "testResultsProcessor",
     "transform",
     "transformIgnorePatterns",
     "watchPathIgnorePatterns"

--- a/scripts/config/createJestConfig.js
+++ b/scripts/config/createJestConfig.js
@@ -39,7 +39,7 @@ module.exports = (resolve, rootDir, isTestMode) => {
     "extraGlobals",
     "globalSetup",
     "globalTeardown",
-    "reporter",
+    "reporters",
     "resetMocks",
     "resetModules",
     "setupFilesAfterEnv",


### PR DESCRIPTION
This PR enables alternative test result processors such as "jest-mocha-reporter". Use case: on a Atlassian Bamboo CI instance, I cannot natively work with jest test results, but mocha would be supported.