### PR TITLE
Sets webpack "node" config to allow path resolution using __dirname

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -132,6 +132,11 @@ module.exports = ignoreWarmupPlugin({
   entry: resolveEntriesPath(slsw.lib.entries),
   target: "node",
   context: __dirname,
+  // allows path resolution using __dirname or __filename in lambda runtime
+  node: {
+    __filename: true,
+    __dirname: true
+  },
   // Disable verbose logs
   stats: ENABLE_STATS ? "normal" : "errors-only",
   devtool: ENABLE_SOURCE_MAPS ? "source-map" : false,


### PR DESCRIPTION
Without the `node` config in webpack, [`__dirname` will be resolve to `/`](https://github.com/webpack/webpack/issues/1599)