### PR TITLE
Upgrading babel-jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/preset-env": "^7.5.4",
     "@babel/runtime": "^7.5.4",
     "babel-eslint": "^10.0.2",
-    "babel-jest": "^24.8.0",
+    "babel-jest": "^25.1.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-source-map-support": "^2.1.1",
     "chalk": "^2.4.2",


### PR DESCRIPTION
running `serverless-bundle test` gives me this warning :point_down: 

`ts-jest[versions] (WARN) Version 24.9.0 of babel-jest installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=25.0.0 <26.0.0). Please do not report issues in ts-jest if you are using unsupported versions.`
