### PR TITLE
Fix for issue 29 - Adding support for aliases

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -15,6 +15,7 @@ const nodeVersion = config.nodeVersion;
 const copyFiles = config.options.copyFiles;
 const ignorePackages = config.options.ignorePackages;
 const fixPackages = convertListToObject(config.options.fixPackages);
+const aliases = config.options.aliases;
 
 const ENABLE_STATS = config.options.stats;
 const ENABLE_LINTING = config.options.linting;
@@ -143,6 +144,18 @@ function plugins() {
   return plugins;
 }
 
+function alias() {
+  let alias;
+  if (Array.isArray(aliases)) {
+    alias = aliases.reduce((obj, item) => {
+      const [key, value] = Object.entries(item)[0];
+      obj[key] = path.join(servicePath, value);
+      return obj;
+    }, {});
+  }
+  return alias;
+}
+
 module.exports = ignoreWarmupPlugin({
   entry: resolveEntriesPath(slsw.lib.entries),
   target: "node",
@@ -160,6 +173,9 @@ module.exports = ignoreWarmupPlugin({
   resolve: {
     // Performance
     symlinks: false,
+
+    alias: alias(),
+
     // First start by looking for modules in the plugin's node_modules
     // before looking inside the project's node_modules.
     modules: [path.resolve(__dirname, "node_modules"), "node_modules"]

--- a/tests/aliases/custom-lib/src/some-lib/index.js
+++ b/tests/aliases/custom-lib/src/some-lib/index.js
@@ -1,0 +1,3 @@
+export function doSomething() {
+  return "done";
+}

--- a/tests/aliases/handler.js
+++ b/tests/aliases/handler.js
@@ -1,0 +1,11 @@
+import { doSomething } from "@my-org/some-lib";
+
+export const hello = async (event, context) => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: doSomething(),
+      input: event
+    })
+  };
+};

--- a/tests/aliases/package-lock.json
+++ b/tests/aliases/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "aliases",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/tests/aliases/package.json
+++ b/tests/aliases/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "aliases",
+  "version": "1.0.0",
+  "description": "",
+  "main": "handler.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/tests/aliases/serverless.yml
+++ b/tests/aliases/serverless.yml
@@ -1,0 +1,17 @@
+service: my-service
+
+custom:
+  bundle:
+    aliases:
+      - "@my-org/some-lib": custom-lib/src/some-lib
+
+plugins:
+  - '../../index'
+
+provider:
+  name: aws
+  runtime: nodejs10.x
+
+functions:
+  hello:
+    handler: handler.hello

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -3,7 +3,8 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 
 const timeout = 10000;
-const errorString = "Error ------------------------------------------";
+const errorString = "Error ------";
+const errorRegex = /(Error|Exception) ---/;
 const eslintErrorString = "no-unused-vars";
 
 const packageCmd = ["package"];
@@ -12,34 +13,39 @@ const invokeCmd = ["invoke", "local", "-f", "hello"];
 beforeEach(clearNpmCache);
 afterAll(clearNpmCache);
 
+test("aliases", () => {
+  const results = runSlsCommand("aliases");
+  expect(results).not.toMatch(errorRegex);
+});
+
 test("base case", () => {
   const results = runSlsCommand("base");
-  expect(results).not.toContain(errorString);
+  expect(results).not.toMatch(errorRegex);
 });
 
 test("class properties", () => {
   const results = runSlsCommand("class-properties");
-  expect(results).not.toContain(errorString);
+  expect(results).not.toMatch(errorRegex);
 });
 
 test("exclude externals", () => {
   const results = runSlsCommand("externals");
-  expect(results).not.toContain(errorString);
+  expect(results).not.toMatch(errorRegex);
 });
 
 test("ignore packages", () => {
   const results = runSlsCommand("ignore-packages");
-  expect(results).not.toContain(errorString);
+  expect(results).not.toMatch(errorRegex);
 });
 
 test("nested lambda", () => {
   const results = runSlsCommand("nested-lambda");
-  expect(results).not.toContain(errorString);
+  expect(results).not.toMatch(errorRegex);
 });
 
 test("nested service", () => {
   const results = runSlsCommand("nested-service/services/main");
-  expect(results).not.toContain(errorString);
+  expect(results).not.toMatch(errorRegex);
 });
 
 test("nested services", () => {
@@ -47,7 +53,7 @@ test("nested services", () => {
     "nested-services/services/service1",
     packageCmd
   );
-  expect(results).not.toContain(errorString);
+  expect(results).not.toMatch(errorRegex);
 });
 
 test("check eslint", () => {
@@ -57,37 +63,37 @@ test("check eslint", () => {
 
 test("override eslint", () => {
   const results = runSlsCommand("override-eslint");
-  expect(results).not.toContain(errorString);
+  expect(results).not.toMatch(errorRegex);
 });
 
 test("disable eslint", () => {
   const results = runSlsCommand("disable-eslint");
-  expect(results).not.toContain(errorString);
+  expect(results).not.toMatch(errorRegex);
 });
 
 test("test eslintignore", () => {
   const results = runSlsCommand("with-eslintignore");
-  expect(results).not.toContain(errorString);
+  expect(results).not.toMatch(errorRegex);
 });
 
 test("ignore warmup plugin", () => {
   const results = runSlsCommand("with-warmup", packageCmd);
-  expect(results).not.toContain(errorString);
+  expect(results).not.toMatch(errorRegex);
 });
 
 test("node 12", () => {
   const results = runSlsCommand("with-node12");
-  expect(results).not.toContain(errorString);
+  expect(results).not.toMatch(errorRegex);
 });
 
 test("invalid runtime", () => {
   const results = runSlsCommand("invalid-runtime");
-  expect(results).not.toContain(errorString);
+  expect(results).not.toMatch(errorRegex);
 });
 
 test("copy files", () => {
   const results = runSlsCommand("copy-files");
-  expect(results).not.toContain(errorString);
+  expect(results).not.toMatch(errorRegex);
   expect(
     fs.existsSync("tests/copy-files/.webpack/service/public/test.txt")
   ).toBe(true);
@@ -95,7 +101,7 @@ test("copy files", () => {
 
 test("fixpackages formidable@1.x", () => {
   const results = runSlsCommand("fixpackages-formidable");
-  expect(results).not.toContain(errorString);
+  expect(results).not.toMatch(errorRegex);
 });
 
 function clearNodeModules(cwd) {


### PR DESCRIPTION
Just a quick change to add support for aliases.

I've also updated the tests in the process and fixed a bug. The tests were checking for the "Error --------------------" string, but the number of dashes was more than what I get when there is an error.

Thus it was not finding and failing tests when it should have. It also didn't check for exceptions. Added both