### PR TITLE
added preset to jest supported keys

### DIFF
--- a/scripts/config/createJestConfig.js
+++ b/scripts/config/createJestConfig.js
@@ -47,7 +47,8 @@ module.exports = (resolve, rootDir, isTestMode) => {
     "testResultsProcessor",
     "transform",
     "transformIgnorePatterns",
-    "watchPathIgnorePatterns"
+    "watchPathIgnorePatterns",
+    "preset"
   ];
   if (overrides) {
     supportedKeys.forEach(key => {


### PR DESCRIPTION
Added support for `preset` configuration property of jest.
All tests seem to be passing.
For example, this allows usage of DynamoDB during tests as describe [here](https://jestjs.io/docs/en/dynamodb) and much more 