### PR TITLE
support aliases with ``serverless-bundle test``

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,8 @@ $ npm test
 To test the `serverless-bundle test` command.
 
 ```bash
-$ npm run test-scripts
+$ cd tests/scripts
+$ npm run test
 ```
 
 To install locally in another project.

--- a/README.md
+++ b/README.md
@@ -340,8 +340,7 @@ $ npm test
 To test the `serverless-bundle test` command.
 
 ```bash
-$ cd tests/scripts
-$ npm run test
+$ npm run test scripts
 ```
 
 To install locally in another project.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,16 @@ custom:
   import Utility from 'Lib/utility';
   ```
 
+  To use aliases in your tests you'll need to use Jest's [`moduleNameMapper`](https://jestjs.io/docs/en/configuration#modulenamemapper-objectstring-string--arraystring). Add the following your `package.json`:
+
+  ``` json
+  "jest": {
+    "moduleNameMapper": {
+      "Lib(.*)$": "<rootDir>/custom-lib/src/lib/$1"
+    }
+  }
+  ```
+
 - Usage with WebStorm
 
   Here is some info on how to get this plugin to support running tests in WebStorm — https://github.com/AnomalyInnovations/serverless-bundle/issues/5#issuecomment-582237396

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/scripts",
-      "<rootDir>/tests/scripts/tests"
+      "<rootDir>/tests/scripts/tests",
+      "<rootDir>/tests/aliases-jest/tests"
     ]
   },
   "repository": {

--- a/scripts/config/createJestConfig.js
+++ b/scripts/config/createJestConfig.js
@@ -45,7 +45,8 @@ module.exports = (resolve, rootDir) => {
     "testResultsProcessor",
     "transform",
     "transformIgnorePatterns",
-    "watchPathIgnorePatterns"
+    "watchPathIgnorePatterns",
+    "moduleNameMapper"
   ];
   if (overrides) {
     supportedKeys.forEach(key => {

--- a/tests/aliases-jest/.eslintrc.json
+++ b/tests/aliases-jest/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "sourceType": "module"
+  }
+}

--- a/tests/aliases-jest/aliases-jest.test.js
+++ b/tests/aliases-jest/aliases-jest.test.js
@@ -1,0 +1,16 @@
+const { runJestCommand, clearNpmCache } = require("../helpers");
+
+beforeEach(async () => {
+  await clearNpmCache(__dirname);
+});
+
+afterAll(async () => {
+  await clearNpmCache(__dirname);
+});
+
+test("aliases-jest", async () => {
+  const result = await runJestCommand(__dirname);
+
+  // Ensure Jest ran the included tests successfully
+  expect(result).not.toMatch(/failed/);
+});

--- a/tests/aliases-jest/handler.js
+++ b/tests/aliases-jest/handler.js
@@ -1,0 +1,11 @@
+import sum from "libs/sum";
+
+const res = (body = {}) => ({
+  statusCode: 200,
+  body: JSON.stringify(body, null, 2)
+});
+
+export const hello = () =>
+  res({
+    sum: sum(1, 2, 3)
+  });

--- a/tests/aliases-jest/libs/sum.js
+++ b/tests/aliases-jest/libs/sum.js
@@ -1,0 +1,1 @@
+export default (...numbers) => numbers.reduce((acc, nbr) => acc + nbr);

--- a/tests/aliases-jest/package-lock.json
+++ b/tests/aliases-jest/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "jest",
+  "name": "aliases-jest",
   "version": "1.0.0",
   "lockfileVersion": 1
 }

--- a/tests/aliases-jest/package.json
+++ b/tests/aliases-jest/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "aliases-jest",
+  "version": "1.0.0",
+  "description": "",
+  "main": "handler.js",
+  "scripts": {
+    "test": "../../bin/scripts.js test --testPathIgnorePatterns=\"./aliases-jest.test.js\""
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "libs(.*)$": "<rootDir>/libs/$1"
+    }
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/tests/aliases-jest/serverless.yml
+++ b/tests/aliases-jest/serverless.yml
@@ -1,0 +1,12 @@
+service: my-service
+
+plugins:
+  - '../../index'
+
+provider:
+  name: aws
+  runtime: nodejs10.x
+
+functions:
+  hello:
+    handler: handler.hello

--- a/tests/aliases-jest/tests/index.test.js
+++ b/tests/aliases-jest/tests/index.test.js
@@ -1,0 +1,8 @@
+import { hello } from "../handler";
+
+test("hello returns sum equal 6 in body", () => {
+  const expected = 6;
+  const actual = JSON.parse(hello().body).sum;
+
+  expect(actual).toBe(expected);
+});

--- a/tests/scripts/package.json
+++ b/tests/scripts/package.json
@@ -6,9 +6,6 @@
   "scripts": {
     "test": "../../bin/scripts.js test --testPathIgnorePatterns=\"./scripts.test.js\""
   },
-  "dependencies": {
-    "jest": "^24.8.0"
-  },
   "jest": {
     "setupFilesAfterEnv": [
       "<rootDir>/setup-tests.js"


### PR DESCRIPTION
#104 Currently, aliases defined in the serverless.yml file are not taken into account when running 'serverless-bundle test'.

I mentionned  [two possible solutions](url).

I went for option 2 (as it was faster to add)

and added ``moduleNameMapper`` to the list of ``acceptedKeys `` in the ``createJestConfig.js`` file.

If this is something you are likely to consider, let me now and I will also update the ``README.md``.

# test
I didn't write any automated tests as it looks like ``npm run test-scripts`` has been removed from the ``.travis.yml`` file.

But I created [a repo you can git clone](https://github.com/chanthafef/serverless-bundle-test-with-alias) to see ``serverless-bundle test`` run with aliases. (checkout the README.md)

# PS
 I also updated the ``README.md`` file to reflect the changes regarding "npm run test-scripts".