### PR TITLE
Set jest testEnvironment to node

### DIFF
--- a/scripts/config/createJestConfig.js
+++ b/scripts/config/createJestConfig.js
@@ -33,7 +33,8 @@ module.exports = (resolve, rootDir) => {
     transform: {
       "^.+\\.(js|jsx)$": resolve("scripts/config/babelJestTransform.js")
     },
-    transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx|ts|tsx)$"]
+    transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx|ts|tsx)$"],
+    testEnvironment: "node"
   };
   if (rootDir) {
     config.rootDir = rootDir;


### PR DESCRIPTION
As detailed in [#73](https://github.com/AnomalyInnovations/serverless-bundle/issues/73#issuecomment-641001872) I think it would make sense to set the jest env to `node`.

Personally I was running into an issue described [here](https://github.com/slackapi/node-slack-sdk/issues/655#issuecomment-431546440)

This could be a breaking change for people's tests, so probably should be semver-major.