### PR TITLE
Add test sequencer to supported keys

### DIFF
--- a/scripts/config/createJestConfig.js
+++ b/scripts/config/createJestConfig.js
@@ -58,7 +58,8 @@ module.exports = (resolve, rootDir) => {
     "transform",
     "transformIgnorePatterns",
     "watchPathIgnorePatterns",
-    "moduleNameMapper"
+    "moduleNameMapper",
+    "testSequencer",
   ];
   if (overrides) {
     supportedKeys.forEach(key => {


### PR DESCRIPTION
Since 24.7.0 Jest supports the key `testSequencer`, which allows you to define a file with the specific test sequence. I tried to changed directly on the node-modules and it worked as expected 😄 