### PR TITLE
fix: remove uncessary console.log()

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -77,7 +77,6 @@ function checkInvalidTsModule() {
   const module = tsCompilerOptions.module;
   const target = tsCompilerOptions.target;
 
-  console.log(module, target);
   return (
     (module !== undefined && module === 1) || // commonjs
     (target !== undefined && (target === 0 || target === 1)) // es3 or es5


### PR DESCRIPTION
Oppps! I assume this wasn't intended to make it out to the deployed package. It ends up printing `5 6` to the console for me when I build my package.