### PR TITLE
set babel sourceType dynamically

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -24,6 +24,7 @@ module.exports = {
     // externals: "all"
     externals: ["knex", "sharp"],
     // Set default file extensions to use the raw-loader with
-    rawFileExtensions: ["pem", "txt"]
+    rawFileExtensions: ["pem", "txt"],
+    sourceType: "module" // "script" | "module" | "unambiguous"
   }
 };

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -34,6 +34,7 @@ const concatText = config.options.concatText;
 const forceExclude = config.options.forceExclude;
 const ignorePackages = config.options.ignorePackages;
 const rawFileExtensions = config.options.rawFileExtensions;
+const sourceType = config.options.sourceType;
 const fixPackages = convertListToObject(config.options.fixPackages);
 const tsConfigPath = path.resolve(servicePath, config.options.tsConfig);
 
@@ -120,6 +121,7 @@ function babelLoader() {
       // Disable compresisng cache files to speed up caching
       cacheCompression: false,
       plugins: plugins.map(require.resolve),
+      sourceType,
       presets: [
         [
           require.resolve("@babel/preset-env"),


### PR DESCRIPTION
Currently using CommonJS require produces an error
``` TypeError: Cannot assign to read only property 'exports' of object '#<Object>'  ```
To change this error one can either switch to ES6 modules or set the sourceType in the babel config to "unambiguous"

