### PR TITLE
Fix forceInclude not being included in the bundle

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -32,6 +32,7 @@ const externals = config.options.externals;
 const copyFiles = config.options.copyFiles;
 const concatText = config.options.concatText;
 const forceExclude = config.options.forceExclude;
+const forceInclude = config.options.forceInclude;
 const ignorePackages = config.options.ignorePackages;
 const rawFileExtensions = config.options.rawFileExtensions;
 const fixPackages = convertListToObject(config.options.fixPackages);
@@ -231,7 +232,10 @@ function loaders() {
       use: [babelLoader(), tsLoader()],
       exclude: [
         [
-          path.resolve(servicePath, "node_modules"),
+          {
+            test: path.resolve(servicePath, "node_modules"),
+            exclude: forceInclude.map(pkg => path.resolve(servicePath, path.join("node_modules", pkg)))
+          },
           path.resolve(servicePath, ".serverless"),
           path.resolve(servicePath, ".webpack")
         ]


### PR DESCRIPTION
This fix allows the packages placed under the `forceInclude` option to obe included in the bundle despite being under node_modules directory.