### PR TITLE
Support serverless-webpack concurrency option

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ function applyWebpackOptions(custom, config) {
     packager: config.options.packager,
     packagerOptions: config.options.packagerOptions,
     webpackConfig: getWebpackConfigPath(config.servicePath),
+    concurrency: config.options.concurrency,
     includeModules: {
       forceExclude: config.options.forceExclude,
       forceInclude: config.options.forceInclude,


### PR DESCRIPTION
This adds support for the `concurrency` option that was added to serverless-webpack in https://github.com/serverless-heaven/serverless-webpack/pull/681

Fixes #205