### PR TITLE
feat(webpack): add excludeFiles for webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,9 +417,9 @@ custom:
     externals: all
 ```
 
-### Externals vs forceExclude
+### Externals vs forceExclude vs excludeFiles
 
-The two options (`externals` and `forceExclude`) look similar but have some subtle differences. Let's look at them in detail:
+The three options (`externals`, `forceExclude`, and `excludeFiles`) look similar but have some subtle differences. Let's look at them in detail:
 
 - `externals`
 
@@ -428,6 +428,10 @@ The two options (`externals` and `forceExclude`) look similar but have some subt
 - `forceExclude`
 
   These packages are available in the Lambda runtime. Either by default (in the case of `aws-sdk`) or through a Lambda layer that you might be using. So these are not included in the Lambda package. And they are also marked as `externals`. Meaning that packages that are in `forceExclude` are automatically added to the `externals` list as well. By default, `aws-sdk` is listed in the `forceExclude`.
+
+- `excludeFiles`
+
+  These are a glob of files that can be excluded from the function resolution. This happens when you have multiple files that are in the same directory and Serverless Framework tries to use them as a function handler. For example, if you have a `index.js` and a `index.test.js` and your function is pointing to `index`, you'll get a warning saying, `WARNING: More than one matching handlers found for index. Using index.js`. To fix this, use `excludeFiles: **/*.test.js`.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ custom:
       - isomorphic-webcrypto          # They'll be included in the node_modules/, more below
     forceExclude:                   # Don't include these in the package
       - chrome-aws-lambda             # Because it'll be provided through a Lambda Layer
+    excludeFiles: "**/*.test.ts"    # Exclude files from Webpack that match the glob
     fixPackages:                    # Include fixes for specific packages
       - "formidable@1.x"              # For ex, formidable@1.x doesn't work by default with Webpack
     copyFiles:                      # Copy any additional files to the generated package

--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ function applyWebpackOptions(custom, config) {
         config.servicePath,
         pkgUp.sync({ cwd: config.servicePath })
       )
-    }
+    },
+    excludeFiles: config.options.excludeFiles
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
       "<rootDir>/scripts",
       "<rootDir>/tests/scripts/tests",
       "<rootDir>/tests/aliases-jest/tests",
-      "<rootDir>/tests/typescript-jest/tests"
+      "<rootDir>/tests/typescript-jest/tests",
+      "<rootDir>/tests/typescript-exclude-files/handler.spec.ts"
     ]
   },
   "repository": {

--- a/src/config.js
+++ b/src/config.js
@@ -14,6 +14,7 @@ module.exports = {
     concatText: null,
     sourcemaps: true,
     forceInclude: null,
+    excludeFiles: null,
     ignorePackages: [],
     packagerOptions: {},
     tsConfig: "tsconfig.json",

--- a/tests/typescript-exclude-files/handler.ts
+++ b/tests/typescript-exclude-files/handler.ts
@@ -1,0 +1,9 @@
+export const hello = async (event: any) => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: "Go Serverless v1.0! Your function executed successfully!",
+      input: event,
+    }),
+  };
+};

--- a/tests/typescript-exclude-files/package-lock.json
+++ b/tests/typescript-exclude-files/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "typescript-config-path",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "typescript-config-path",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/tests/typescript-exclude-files/package.json
+++ b/tests/typescript-exclude-files/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "typescript-config-path",
+  "version": "1.0.0",
+  "description": "",
+  "main": "handler.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/tests/typescript-exclude-files/serverless.yml
+++ b/tests/typescript-exclude-files/serverless.yml
@@ -1,0 +1,16 @@
+service: my-service
+
+plugins:
+  - '../../index'
+
+custom:
+  bundle:
+    excludeFiles: '*.spec.ts'
+
+provider:
+  name: aws
+  runtime: nodejs10.x
+
+functions:
+  hello:
+    handler: handler.hello

--- a/tests/typescript-exclude-files/tsconfig.json
+++ b/tests/typescript-exclude-files/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "moduleResolution": "node",
+    "baseUrl": "."
+  }
+}

--- a/tests/typescript-exclude-files/typescript-exclude-files.test.js
+++ b/tests/typescript-exclude-files/typescript-exclude-files.test.js
@@ -1,0 +1,18 @@
+const { runSlsCommand, clearNpmCache, errorRegex } = require("../helpers");
+
+beforeEach(async () => {
+  await clearNpmCache(__dirname);
+});
+
+afterAll(async () => {
+  await clearNpmCache(__dirname);
+});
+
+test("typescript-exclude-files", async () => {
+  const result = await runSlsCommand(__dirname);
+
+  expect(result).not.toMatch(
+    "WARNING: More than one matching handlers found for 'handler'. Using 'handler.ts'."
+  );
+  expect(result).not.toMatch(errorRegex);
+});


### PR DESCRIPTION
This pull request introduces `excludeFiles` for the Webpack configuration, this is mainly to stop the warning of duplicate handlers. 

This addresses this issue: https://github.com/AnomalyInnovations/serverless-bundle/issues/189