### PR TITLE
Register `serverless` as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,9 @@
     "lint-staged": "^9.4.2",
     "prettier": "1.18.2"
   },
+  "peerDependencies": {
+    "serverless": "1 || 2"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"


### PR DESCRIPTION
It's to ensure only compatible versions or Framework are used together with a plugin, and if mismatch occurs, user is informed with meaningful error message.

_This PR is part of Serverless Framework initiative to [curate most popular plugins](https://github.com/serverless/serverless/issues/9025)_

