### PR TITLE
Updates jest `supportedKeys` with more options

### DIFF
--- a/scripts/config/createJestConfig.js
+++ b/scripts/config/createJestConfig.js
@@ -43,23 +43,28 @@ module.exports = (resolve, rootDir) => {
   }
   const overrides = Object.assign({}, require(paths.appPackageJson).jest);
   const supportedKeys = [
+    "clearMocks",
     "collectCoverageFrom",
+    "coveragePathIgnorePatterns",
     "coverageReporters",
     "coverageThreshold",
+    "displayName",
     "extraGlobals",
     "globalSetup",
     "globalTeardown",
     "reporters",
     "resetMocks",
     "resetModules",
+    "restoreMocks",
     "setupFilesAfterEnv",
     "snapshotSerializers",
+    "testMatch",
     "testResultsProcessor",
     "transform",
     "transformIgnorePatterns",
     "watchPathIgnorePatterns",
     "moduleNameMapper",
-    "testSequencer",
+    "testSequencer"
   ];
   if (overrides) {
     supportedKeys.forEach(key => {

--- a/scripts/config/createJestConfig.js
+++ b/scripts/config/createJestConfig.js
@@ -64,7 +64,7 @@ module.exports = (resolve, rootDir) => {
     "transformIgnorePatterns",
     "watchPathIgnorePatterns",
     "moduleNameMapper",
-    "testSequencer"
+    "testSequencer",
   ];
   if (overrides) {
     supportedKeys.forEach(key => {


### PR DESCRIPTION
This is a short and sweet PR that adds a couple of options to the `supportedKeys` in `createJestConfig.js` to match what's live on [Create React App](https://github.com/facebook/create-react-app/blob/main/packages/react-scripts/scripts/utils/createJestConfig.js). In particular, it adds:

* [`clearMocks`](https://jestjs.io/docs/configuration#clearmocks-boolean)
* [`coveragePathIgnorePatterns`](https://jestjs.io/docs/configuration#coveragepathignorepatterns-arraystring)
* [`displayName`](https://jestjs.io/docs/configuration#displayname-string-object)
* [`restoreMocks`](https://jestjs.io/docs/configuration#restoremocks-boolean)
* [`testMatch`](https://jestjs.io/docs/configuration#restoremocks-boolean)

It's a quick addition from #73 but doesn't implement the broader-scale strategy of respecting the user's Jest config file, etc. Instead, the goal of this PR is just to get this repo up-to-date with some newer jest options (and not introduce any breaking changes, etc.).

More than happy to add other keys to this PR, such as `bail`, `verbose`, or `preset` as suggested in #73.