### PR TITLE
Allow boolean values (`false`) in webpack config `resolve.alias`

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,19 @@ custom:
   }
   ```
 
+- Excluding modules from bundling
+
+  In some cases it might be neccessary to exclude certain modules from bundling with Webpack. This can be achieved by setting the module alias to `false`:
+
+  ``` yml
+  custom:
+    bundle:
+      aliases:
+        - "module-name": false
+  ```
+
+  The `aliases` option is explained in detail in the [Webpack documentation](https://webpack.js.org/configuration/resolve/#resolvealias).
+
 - Usage with WebStorm
 
   Here is some info on how to get this plugin to support running tests in WebStorm — https://github.com/AnomalyInnovations/serverless-bundle/issues/5#issuecomment-582237396

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -408,7 +408,11 @@ function resolvePlugins() {
 function alias() {
   return aliases.reduce((obj, item) => {
     const [key, value] = Object.entries(item)[0];
-    obj[key] = path.join(servicePath, value);
+    if (typeof value === "string") {
+      obj[key] = path.join(servicePath, value);
+    } else {
+      obj[key] = value;
+    }
     return obj;
   }, {});
 }

--- a/tests/aliases-false/aliases-false.test.js
+++ b/tests/aliases-false/aliases-false.test.js
@@ -1,0 +1,21 @@
+const { runSlsCommand, clearNpmCache } = require("../helpers");
+
+beforeEach(async () => {
+  await clearNpmCache(__dirname);
+});
+
+afterAll(async () => {
+  await clearNpmCache(__dirname);
+});
+
+test("aliases-false", async () => {
+  expect.assertions(1);
+
+  const webpackErrorRegex = /"TypeError: is_sorted(.*)is not a function"/;
+
+  try {
+    await runSlsCommand(__dirname);
+  } catch (err) {
+    expect(err.stdout).toMatch(webpackErrorRegex);
+  }
+});

--- a/tests/aliases-false/handler.js
+++ b/tests/aliases-false/handler.js
@@ -1,0 +1,12 @@
+import sorted from "is-sorted";
+
+export const hello = async (event) => {
+  sorted([1, 2, 3]);
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: "Go Serverless v1.0! Your function executed successfully!",
+      input: event,
+    }),
+  };
+};

--- a/tests/aliases-false/package.json
+++ b/tests/aliases-false/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "aliases-false",
+  "version": "1.0.0",
+  "description": "",
+  "main": "handler.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "is-sorted": "^1.0.5"
+  }
+}

--- a/tests/aliases-false/serverless.yml
+++ b/tests/aliases-false/serverless.yml
@@ -1,0 +1,17 @@
+service: my-service
+
+plugins:
+  - "../../index"
+
+custom:
+  bundle:
+    aliases:
+      - "is-sorted": false
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+
+functions:
+  hello:
+    handler: handler.hello


### PR DESCRIPTION
Hi @jayair,

I ran into an issue where we needed to set a module alias to `false` in the webpack resolve config to ignore that module:
```yml
# serverless.yml
custom:
  bundle:
    aliases:
      - '<module-name>': false
```

See the last paragraph of https://webpack.js.org/configuration/resolve/#resolvealias for details.

Unfortunately, this is not currently possible with `serverless-bundle` as it only supports strings (paths) at this place. I've created this PR with an extension to resolve this issue and I hope it finds your favour.