### PR TITLE
Mark plugin as Serverless Framework v3 ready

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "serverless": "^2.37.1"
   },
   "peerDependencies": {
-    "serverless": "1 || 2"
+    "serverless": "1 || 2 || 3"
   },
   "lint-staged": {
     "*.{js,css,json,md}": [


### PR DESCRIPTION
Plugin is confirmed to work with v3 release without issues, therefore it'll be good whitelist v3 of the Framework in peer dependencies section