### PR TITLE
Set default testEnvironment to 'node'

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -58,7 +58,7 @@ function resolveJestDefaultEnvironment(name) {
   });
 }
 let cleanArgv = [];
-let env = "jsdom";
+let env = "node";
 let next;
 do {
   next = argv.shift();


### PR DESCRIPTION
First of all: create library, very nice to use!

We are using mongoose in our tests and where always wondering why it was printing the warning `Mongoose: looks like you're trying to test a Mongoose app with Jest's default jsdom test environment.` while this library sets the testEnvironment to `node`. Now I found that the testEnvironment in the config is not actually used, because it is overwritten by the code in test.js.
Hence this pull request 😊 