### PR TITLE
Set fully specified resolution rule to false in js loader

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -191,6 +191,9 @@ function loaders() {
     test: /\.js$/,
     exclude: /node_modules/,
     use: [ENABLE_ESBUILD ? esbuildLoader("jsx") : babelLoader()],
+    resolve: {
+      fullySpecified: false,
+    },
   };
 
   const loaders = {
@@ -298,7 +301,7 @@ function plugins() {
 
     if (ENABLE_LINTING) {
       if (parsedTsConfig.exclude) {
-        tsEslintConfig.ignorePatterns = parsedTsConfig.exclude
+        tsEslintConfig.ignorePatterns = parsedTsConfig.exclude;
       }
       forkTsCheckerWebpackOptions.eslint = {
         files: path.join(servicePath, "**/*.ts"),


### PR DESCRIPTION
Hello! Would just like to say thank you to those that maintain this project! It has saved me so much time over the years. I ran into a slight issue where I wasn't able to build my typescript es module project and this is the fix that allowed me to do so!

Looked around for how testing was done in the repo and noticed that the other usage of `fullySpecified` in the `javascript/auto` loader didn't have any corresponding tests so I didn't add any.

Let me know what I need to do to get this PR up to spec and ready to be merged if it's the right approach for tackling this problem! :D

This is the error I was getting because I don't want to move to the new extension included import scheme as yet   ::

```
ERROR in ../../../backend/microservices/stripe-microservice/dist/src/main-serverless.js 3:0-72
Module not found: Error: Can't resolve './stripe-microservice.module' in '/Users/carlswann/src/tingsly/microservices/packages/backend/microservices/stripe-microservice/dist/src'
Did you mean 'stripe-microservice.module.js'?
BREAKING CHANGE: The request './stripe-microservice.module' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```