### PR TITLE
Add 'transpileOnly' option to skip TS checking altogether

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ custom:
     linting: true                   # Enable linting as a part of the build process
     generateStatsFiles: false       # Creates stats files that could be used for bundle analyzing, more below
     esbuild: false                  # Use esbuild-loader instead of babel or ts for faster builds
+    transpileOnly: false            # Disable TypeScript type-checking
     disableForkTsChecker: false     # Disable the ForkTsChecker plugin, more below
     tsConfig: "tsconfig.json"       # Path to your 'tsconfig.json', if it's not in the root
     forceInclude:                   # Optional list of NPM packages that need to be included

--- a/src/config.js
+++ b/src/config.js
@@ -23,6 +23,7 @@ module.exports = {
     // Exclude aws-sdk since it's available in the Lambda runtime
     forceExclude: ["aws-sdk"],
     disableForkTsChecker: false,
+    transpileOnly: false,
     // Set non Webpack compatible packages as externals
     // Or if we want to exclude all packages in the node_modules:
     // externals: "all"

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -46,7 +46,8 @@ const ENABLE_STATS = config.options.stats;
 const ENABLE_LINTING = config.options.linting;
 const ENABLE_SOURCE_MAPS = config.options.sourcemaps;
 const ENABLE_TYPESCRIPT = fs.existsSync(tsConfigPath);
-const ENABLE_TSCHECKER = !config.options.disableForkTsChecker;
+const ENABLE_TS_CHECKER = !config.options.transpileOnly
+const ENABLE_FORK_TS_CHECKER = ENABLE_TS_CHECKER && !config.options.disableForkTsChecker;
 const GENERATE_STATS_FILES = config.options.generateStatsFiles;
 const ENABLE_CACHING = isLocal ? config.options.caching : false;
 
@@ -180,8 +181,7 @@ function tsLoader() {
       projectReferences: true,
       configFile: tsConfigPath,
       experimentalWatchApi: true,
-      // Don't check types if ForTsChecker is enabled
-      transpileOnly: ENABLE_TSCHECKER,
+      transpileOnly: !ENABLE_TS_CHECKER || ENABLE_FORK_TS_CHECKER,
     },
   };
 }
@@ -288,7 +288,7 @@ function plugins() {
     );
   }
 
-  if (ENABLE_TYPESCRIPT && ENABLE_TSCHECKER) {
+  if (ENABLE_TYPESCRIPT && ENABLE_FORK_TS_CHECKER) {
     const forkTsCheckerWebpackOptions = {
       typescript: {
         configFile: tsConfigPath,
@@ -319,7 +319,7 @@ function plugins() {
     );
 
     // If the ForkTsChecker is disabled, then let Eslint do the linting
-    if (ENABLE_TYPESCRIPT && !ENABLE_TSCHECKER) {
+    if (ENABLE_TYPESCRIPT && !ENABLE_FORK_TS_CHECKER) {
       plugins.push(
         new ESLintPlugin({
           context: servicePath,

--- a/tests/typescript-transpile-only/handler.ts
+++ b/tests/typescript-transpile-only/handler.ts
@@ -1,0 +1,14 @@
+export const hello = async (event: any) => {
+  const unsed = "I should be flagged as an unused variable"
+  const thing = { a: 1, b: 2 }
+
+  // Package with `transpileOnly: true` should ignore TypeScript errors.
+  void thing.c
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: `Go Serverless v1.0! Your function executed successfully!`,
+      input: event,
+    }),
+  };
+};

--- a/tests/typescript-transpile-only/package-lock.json
+++ b/tests/typescript-transpile-only/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "typescript-transpile-only",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/tests/typescript-transpile-only/package.json
+++ b/tests/typescript-transpile-only/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "typescript-transpile-only",
+  "version": "1.0.0",
+  "description": "",
+  "main": "handler.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/tests/typescript-transpile-only/serverless.yml
+++ b/tests/typescript-transpile-only/serverless.yml
@@ -1,0 +1,16 @@
+service: my-service
+
+plugins:
+  - '../../index'
+
+custom:
+  bundle:
+    transpileOnly: true
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+
+functions:
+  hello:
+    handler: handler.hello

--- a/tests/typescript-transpile-only/tsconfig.json
+++ b/tests/typescript-transpile-only/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "moduleResolution": "node",
+    "baseUrl": "."
+  }
+}

--- a/tests/typescript-transpile-only/typescript-forkts-disabled.test.js
+++ b/tests/typescript-transpile-only/typescript-forkts-disabled.test.js
@@ -1,0 +1,23 @@
+const { runSlsCommand, clearNpmCache } = require("../helpers");
+
+beforeEach(async () => {
+  await clearNpmCache(__dirname);
+});
+
+afterAll(async () => {
+  await clearNpmCache(__dirname);
+});
+
+// Test that we are running eslint even with `transpileOnly: true` and that the
+// package gets built even with TS errors.
+test("typescript-transpile-only", async () => {
+  expect.assertions(1);
+
+  const eslintErrorString = "no-unused-vars";
+
+  try {
+    await runSlsCommand(__dirname);
+  } catch (err) {
+    expect(err.stdout).toContain(eslintErrorString);
+  }
+});


### PR DESCRIPTION
This option (disabled by default) will skip type-checking altogether, which is useful for projects that run the TypeScript type checker separately and just want serverless-bundle for transpilation and bundling.