### PR TITLE
feat: add ability to use webpack experiments

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="31ff78e2-a6cc-4fcd-951e-7b14cb69538d" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ProjectLevelVcsManager" settingsEditedManually="true" />
+  <component name="TaskManager">
+    <servers />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ custom:
         - echo hello > test
     rawFileExtensions:              # An array of file extensions to import using the Webpack raw-loader.
       - csv                         # Defaults to ['pem', 'txt']
+    experiments:                    # Give the ability to activate and try out experimental features of webpack
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ custom:
         - echo hello > test
     rawFileExtensions:              # An array of file extensions to import using the Webpack raw-loader.
       - csv                         # Defaults to ['pem', 'txt']
-    experiments:                    # Give the ability to activate and try out experimental features of webpack
+    experiments:                    # Give the ability to activate and try out experimental features of Webpack
 
 ```
 

--- a/src/config.js
+++ b/src/config.js
@@ -29,5 +29,6 @@ module.exports = {
     externals: ["knex", "sharp"],
     // Set default file extensions to use the raw-loader with
     rawFileExtensions: ["pem", "txt"],
+    experiments: {}
   },
 };

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -40,6 +40,7 @@ const ignorePackages = config.options.ignorePackages;
 const rawFileExtensions = config.options.rawFileExtensions;
 const fixPackages = convertListToObject(config.options.fixPackages);
 const tsConfigPath = path.resolve(servicePath, config.options.tsConfig);
+const experiments = config.options.experiments;
 
 const ENABLE_ESBUILD = config.options.esbuild;
 const ENABLE_STATS = config.options.stats;
@@ -478,6 +479,7 @@ module.exports = {
         ],
       },
   plugins: plugins(),
+  experiments,
   node: {
     __dirname: false,
   },

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -34,13 +34,13 @@ const nodeVersion = config.nodeVersion;
 const externals = config.options.externals;
 const copyFiles = config.options.copyFiles;
 const concatText = config.options.concatText;
+const experiments = config.options.experiments;
 const esbuildNodeVersion = "node" + nodeVersion;
 const forceExclude = config.options.forceExclude;
 const ignorePackages = config.options.ignorePackages;
 const rawFileExtensions = config.options.rawFileExtensions;
 const fixPackages = convertListToObject(config.options.fixPackages);
 const tsConfigPath = path.resolve(servicePath, config.options.tsConfig);
-const experiments = config.options.experiments;
 
 const ENABLE_ESBUILD = config.options.esbuild;
 const ENABLE_STATS = config.options.stats;


### PR DESCRIPTION
Hi everyone, 

I've created PR regarding [this issue](https://github.com/AnomalyInnovations/serverless-bundle/issues/300)
It extends config with the new option [experiments](https://webpack.js.org/configuration/experiments/) comes from webpack.