### PR TITLE
Don't use tsconfig-paths-webpack-plugin if no baseUrl defined

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -299,7 +299,7 @@ function plugins() {
 
     if (ENABLE_LINTING) {
       if (parsedTsConfig.exclude) {
-        tsEslintConfig.ignorePatterns = parsedTsConfig.exclude
+        tsEslintConfig.ignorePatterns = parsedTsConfig.exclude;
       }
       forkTsCheckerWebpackOptions.eslint = {
         files: path.join(servicePath, "**/*.ts"),
@@ -413,7 +413,7 @@ function plugins() {
 function resolvePlugins() {
   const plugins = [];
 
-  if (ENABLE_TYPESCRIPT) {
+  if (ENABLE_TYPESCRIPT && (parsedTsConfig.options || {}).baseUrl) {
     plugins.push(
       new TsconfigPathsPlugin({
         configFile: tsConfigPath,

--- a/tests/helpers/run-sls-command.js
+++ b/tests/helpers/run-sls-command.js
@@ -6,15 +6,17 @@ const execPromise = promisify(exec);
 const TIMEOUT = 30000;
 const INVOKE_CMD = "invoke local -f hello -l --data {}";
 
-async function runSlsCommand(cwd, cmd = INVOKE_CMD) {
+async function runSlsCommand(cwd, cmd = INVOKE_CMD, includeStderr = false) {
   await npmInstall(cwd);
 
-  const { stdout } = await execPromise(`serverless ${cmd}`, {
+  const { stdout, stderr } = await execPromise(`serverless ${cmd}`, {
     cwd,
-    TIMEOUT
+    TIMEOUT,
   });
 
-  return stdout.toString("utf8");
+  return includeStderr
+    ? stdout.toString("utf8") + stderr.toString("utf8")
+    : stdout.toString("utf8");
 }
 
 module.exports = runSlsCommand;

--- a/tests/typescript-no-baseUrl/handler.ts
+++ b/tests/typescript-no-baseUrl/handler.ts
@@ -1,0 +1,9 @@
+export const hello = async (event: any) => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: "No baseUrl",
+      input: event,
+    }),
+  };
+};

--- a/tests/typescript-no-baseUrl/package-lock.json
+++ b/tests/typescript-no-baseUrl/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "typescript-no-baseUrl",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/tests/typescript-no-baseUrl/package.json
+++ b/tests/typescript-no-baseUrl/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "typescript-no-baseUrl",
+  "version": "1.0.0",
+  "description": "",
+  "main": "handler.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/tests/typescript-no-baseUrl/serverless.yml
+++ b/tests/typescript-no-baseUrl/serverless.yml
@@ -1,0 +1,14 @@
+service: my-service
+
+plugins:
+  - '../../index'
+
+custom:
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+
+functions:
+  hello:
+    handler: handler.hello

--- a/tests/typescript-no-baseUrl/tsconfig.json
+++ b/tests/typescript-no-baseUrl/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "moduleResolution": "node"
+  }
+}

--- a/tests/typescript-no-baseUrl/typescript-no-baseUrl.test.js
+++ b/tests/typescript-no-baseUrl/typescript-no-baseUrl.test.js
@@ -1,0 +1,16 @@
+const { runSlsCommand, clearNpmCache } = require("../helpers");
+
+beforeEach(async () => {
+  await clearNpmCache(__dirname);
+});
+
+afterAll(async () => {
+  await clearNpmCache(__dirname);
+});
+
+test("typescript-no-baseUrl", async () => {
+  const result = await runSlsCommand(__dirname, "package", true);
+
+  expect(result).not.toMatch(/Failed to load/);
+  expect(result).not.toMatch(/Found no baseUrl/);
+});


### PR DESCRIPTION
We have a typescript project with no `baseUrl` defined in `compilerOptions`, which causes errors like the following when bundling: 

```
Packaging [redacted] for stage staging (us-east-1)
Failed to load /[redacted]/tsconfig.json: Missing baseUrl in compilerOptions
Bundling with Webpack...
tsconfig-paths-webpack-plugin: Found no baseUrl in tsconfig.json, not applying tsconfig-paths-webpack-plugin
tsconfig-paths-webpack-plugin: Found no baseUrl in tsconfig.json, not applying tsconfig-paths-webpack-plugin
tsconfig-paths-webpack-plugin: Found no baseUrl in tsconfig.json, not applying tsconfig-paths-webpack-plugin
...
```

This PR changes the webpack config to skip adding `tsconfig-paths-webpack-plugin` if no baseUrl is defined.

To test it, I added a flag to the `runSlsCommand` helper, that includes stderr output (as well as stdout) in the returned string.
You might want to do something different there but this seemed like the smallest possible change.