### PR TITLE
FIX: When using ESM, resolve Typescript imports using .js extension

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -455,6 +455,10 @@ module.exports = {
     // Performance
     symlinks: false,
     extensions: extensions,
+    extensionAlias: {
+      ".js": [".ts", ".js"],
+      ".mjs": [".mts", ".mjs"]
+    },
     alias: alias(),
     // First start by looking for modules in the plugin's node_modules
     // before looking inside the project's node_modules.


### PR DESCRIPTION
When using ESM imports and Typescript, the convention that the typescript team is pushing is to import typescript `.ts` files using `.js` file extension when using ESM modules in Node16 or NodeNext.

See this issue for more background: #TypeStrong/ts-loader/issues/111

However, older version of `webpack` (prior to v.5.74.0) could not resolve these typescript files with `.js` extension.

#Environment
ESM Modules, NodeNext

# Observed Behaviour
ERROR in ../handler.ts 5:32-66
Module not found: Error: Can't resolve './balancesController.js' in '\sigma'
// balancesController file is named balancesController.ts

# How to Fix
`webpack` bundled with `serverless-bundle` *can resolve* these filenames since `webpack` version v5.74.0, which gets included in the `serverless-bundle` repo. However, it requires some small modification to the `webpack.config.js` file, which is not exposed on `serverless-bundle`. Namely, we need to add an extension alias to `module.exports.resolve`

I have to add these lines in manually to my node_modules for serverless-bundle each time. Think will be relevant to have in the base configuration as more people may be using ESM modules.