### PR TITLE
Fix Nodes Spawn Error due to Security Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "resolve": "^1.22.0",
     "sass": "^1.49.7",
     "sass-loader": "^11.1.1",
-    "serverless-webpack": "^5.6.1",
+    "serverless-webpack": "^5.14.2",
     "source-map-support": "^0.5.21",
     "ts-jest": "^29.2.5",
     "ts-loader": "^8.3.0",


### PR DESCRIPTION
Hi! 

Node release a security update preventing spawning .cmd processes which is what serverless-webpack does.
(Read: https://github.com/serverless-heaven/serverless-webpack/issues/1791 and https://github.com/nodejs/node/issues/52554)

This PR bumps serverless-webpack to the fixed version.

Thanks!

Ref: 
https://github.com/nodejs/node/issues/52554
https://github.com/serverless/serverless/issues/12434
https://github.com/medikoo/cli-progress-footer/issues/2
